### PR TITLE
Release 1.6

### DIFF
--- a/src/SprykerEco/Client/Adyen/Zed/AdyenStub.php
+++ b/src/SprykerEco/Client/Adyen/Zed/AdyenStub.php
@@ -75,7 +75,7 @@ class AdyenStub implements AdyenStubInterface
     public function handleCreditCard3dResponseFromAdyen(AdyenRedirectResponseTransfer $redirectResponseTransfer): AdyenRedirectResponseTransfer
     {
         /** @var \Generated\Shared\Transfer\AdyenRedirectResponseTransfer $redirectResponseTransfer */
-        $redirectResponseTransfer = $this->zedRequestClient->call('/adyen/gateway/handle-credit-card-3d-response', $redirectResponseTransfer);
+        $redirectResponseTransfer = $this->zedRequestClient->call('/adyen/gateway/handle-credit-card3d-response', $redirectResponseTransfer);
 
         return $redirectResponseTransfer;
     }

--- a/src/SprykerEco/Yves/Adyen/Form/CreditCardSubForm.php
+++ b/src/SprykerEco/Yves/Adyen/Form/CreditCardSubForm.php
@@ -35,7 +35,7 @@ class CreditCardSubForm extends AbstractSubForm
 
     protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_CARD_NUMBER = 'adyen.payment.error.cc_number';
     protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_EXPIRY_YEAR = 'adyen.payment.error.cc_year';
-    protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_EXPIRY_MONTH = 'adyen.payment.error.cc_month.';
+    protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_EXPIRY_MONTH = 'adyen.payment.error.cc_month';
     protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_SECURITY_CODE = 'adyen.payment.error.cc_cvv';
 
     /**

--- a/src/SprykerEco/Yves/Adyen/Form/DirectDebitSubForm.php
+++ b/src/SprykerEco/Yves/Adyen/Form/DirectDebitSubForm.php
@@ -25,6 +25,10 @@ class DirectDebitSubForm extends AbstractSubForm
     protected const OWNER_NAME_LABEL = 'Owner Name';
     protected const IBAN_NUMBER_LABEL = 'IBAN';
 
+    protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_OWNER_NAME = 'adyen.payment.error.owner_name';
+    protected const GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_IBAN_NUMBER = 'adyen.payment.error.iban_number';
+
+
     /**
      * @return string
      */
@@ -87,7 +91,9 @@ class DirectDebitSubForm extends AbstractSubForm
             [
                 'label' => static::OWNER_NAME_LABEL,
                 'required' => true,
-                'constraints' => [],
+                'constraints' => [
+                    $this->createNotBlankConstraint(static::GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_OWNER_NAME),
+                ],
             ]
         );
 
@@ -107,7 +113,9 @@ class DirectDebitSubForm extends AbstractSubForm
             [
                 'label' => static::IBAN_NUMBER_LABEL,
                 'required' => true,
-                'constraints' => [],
+                'constraints' => [
+                    $this->createNotBlankConstraint(static::GLOSSARY_KEY_CONSTRAINT_MESSAGE_INVALID_IBAN_NUMBER),
+                ],
             ]
         );
 

--- a/src/SprykerEco/Yves/Adyen/Theme/default/components/molecules/adyen-credit-card/index.ts
+++ b/src/SprykerEco/Yves/Adyen/Theme/default/components/molecules/adyen-credit-card/index.ts
@@ -1,4 +1,6 @@
 import './adyen-credit-card.scss';
-
 import register from 'ShopUi/app/registry';
-export default register('adyen-credit-card', () => import(/* webpackMode: "lazy" */'./adyen-credit-card'));
+export default register('adyen-credit-card', () => import(
+    /* webpackMode: "lazy" */
+    /* webpackChunkName: "adyen-credit-card" */
+    './adyen-credit-card'));

--- a/src/SprykerEco/Yves/Adyen/Theme/default/components/molecules/credit-card/index.ts
+++ b/src/SprykerEco/Yves/Adyen/Theme/default/components/molecules/credit-card/index.ts
@@ -1,4 +1,6 @@
 import './credit-card.scss';
-
 import register from 'ShopUi/app/registry';
-export default register('credit-card', () => import(/* webpackMode: "lazy" */'./credit-card'));
+export default register('credit-card', () => import(
+    /* webpackMode: "lazy" */
+    /* webpackChunkName: "credit-card" */
+    './credit-card'));

--- a/src/SprykerEco/Zed/Adyen/Business/Order/AdyenOrderPaymentManager.php
+++ b/src/SprykerEco/Zed/Adyen/Business/Order/AdyenOrderPaymentManager.php
@@ -42,7 +42,7 @@ class AdyenOrderPaymentManager implements AdyenOrderPaymentManagerInterface
      * @param \Generated\Shared\Transfer\QuoteTransfer $quoteTransfer
      * @param \Generated\Shared\Transfer\SaveOrderTransfer $saveOrderTransfer
      *
-     * @throws SprykerEco\Zed\Adyen\Business\Exception\AdyenMethodSaverException
+     * @throws \SprykerEco\Zed\Adyen\Business\Exception\AdyenMethodSaverException
      *
      * @return void
      */

--- a/src/SprykerEco/Zed/Adyen/Persistence/Propel/Schema/spy_payment_adyen.schema.xml
+++ b/src/SprykerEco/Zed/Adyen/Persistence/Propel/Schema/spy_payment_adyen.schema.xml
@@ -3,22 +3,22 @@
 
     <table name="spy_payment_adyen">
         <column name="id_payment_adyen" required="true" type="INTEGER" autoIncrement="true" primaryKey="true"/>
-        <column name="fk_sales_order" required="true" type="INTEGER" />
+        <column name="fk_sales_order" required="true" type="INTEGER"/>
 
-        <column name="payment_method" required="true" type="VARCHAR" />
-        <column name="order_reference" required="true" type="VARCHAR" />
-        <column name="reference" required="true" type="VARCHAR" />
-        <column name="psp_reference" required="false" type="VARCHAR" />
-        <column name="details" required="false" type="VARCHAR" />
-        <column name="payment_data" required="false" type="VARCHAR" />
-        <column name="additional_data" required="false" type="VARCHAR" />
+        <column name="payment_method" required="true" type="VARCHAR" size="64"/>
+        <column name="order_reference" required="true" type="VARCHAR" size="64"/>
+        <column name="reference" required="true" type="VARCHAR" size="128"/>
+        <column name="psp_reference" required="false" type="VARCHAR" size="64"/>
+        <column name="details" required="false" type="LONGVARCHAR"/>
+        <column name="payment_data" required="false" type="LONGVARCHAR"/>
+        <column name="additional_data" required="false" type="LONGVARCHAR"/>
 
         <foreign-key name="spy_payment_adyen-fk_sales_order" foreignTable="spy_sales_order" phpName="SpySalesOrder">
             <reference foreign="id_sales_order" local="fk_sales_order"/>
         </foreign-key>
 
         <unique name="spy_payment_adyen-unique-order_reference">
-            <unique-column name="order_reference" />
+            <unique-column name="order_reference"/>
         </unique>
 
         <behavior name="timestampable"/>
@@ -30,7 +30,7 @@
         <column name="fk_payment_adyen" type="INTEGER" required="true"/>
         <column name="fk_sales_order_item" type="INTEGER" required="true"/>
 
-        <column name="status" required="true" type="VARCHAR"/>
+        <column name="status" required="true" type="VARCHAR" size="64"/>
 
         <behavior name="timestampable"/>
 
@@ -53,16 +53,16 @@
     <table name="spy_payment_adyen_api_log">
         <column name="id_payment_adyen_api_log" required="true" type="INTEGER" primaryKey="true" autoIncrement="true"/>
 
-        <column name="type" required="true" type="VARCHAR"/>
-        <column name="request" required="true" type="VARCHAR"/>
+        <column name="type" required="true" type="VARCHAR" size="128"/>
+        <column name="request" required="true" type="LONGVARCHAR"/>
         <column name="is_success" required="true" type="BOOLEAN"/>
 
-        <column name="response" required="true" type="VARCHAR"/>
+        <column name="response" required="true" type="LONGVARCHAR"/>
 
-        <column name="status_code" required="false" type="INTEGER" />
-        <column name="error_code" required="false" type="VARCHAR" />
-        <column name="error_message" required="false" type="VARCHAR" />
-        <column name="error_type" required="false" type="VARCHAR" />
+        <column name="status_code" required="false" type="INTEGER"/>
+        <column name="error_code" required="false" type="VARCHAR" size="128"/>
+        <column name="error_message" required="false" type="VARCHAR" size="255"/>
+        <column name="error_type" required="false" type="VARCHAR" size="128"/>
 
         <behavior name="timestampable"/>
 
@@ -72,18 +72,18 @@
     <table name="spy_payment_adyen_notification">
         <column name="id_payment_adyen_notification" required="true" type="INTEGER" primaryKey="true" autoIncrement="true"/>
 
-        <column name="psp_reference" required="true" type="VARCHAR"/>
-        <column name="event_code" required="true" type="VARCHAR"/>
-        <column name="success" required="true" type="VARCHAR"/>
+        <column name="psp_reference" required="true" type="VARCHAR" size="64"/>
+        <column name="event_code" required="true" type="VARCHAR" size="128"/>
+        <column name="success" required="true" type="VARCHAR" size="32"/>
 
-        <column name="additional_data" required="false" type="VARCHAR"/>
-        <column name="amount" required="false" type="VARCHAR"/>
-        <column name="operations" required="false" type="VARCHAR"/>
-        <column name="event_date" required="false" type="VARCHAR"/>
-        <column name="merchant_account_code" required="false" type="VARCHAR"/>
-        <column name="merchant_reference" required="false" type="VARCHAR"/>
-        <column name="payment_method" required="false" type="VARCHAR"/>
-        <column name="reason" required="false" type="VARCHAR"/>
+        <column name="additional_data" required="false" type="LONGVARCHAR"/>
+        <column name="amount" required="false" type="VARCHAR" size="32"/>
+        <column name="operations" required="false" type="VARCHAR" size="255"/>
+        <column name="event_date" required="false" type="VARCHAR" size="255"/>
+        <column name="merchant_account_code" required="false" type="VARCHAR" size="255"/>
+        <column name="merchant_reference" required="false" type="VARCHAR" size="128"/>
+        <column name="payment_method" required="false" type="VARCHAR" size="128"/>
+        <column name="reason" required="false" type="VARCHAR" size="255"/>
 
         <behavior name="timestampable"/>
 


### PR DESCRIPTION
- Developer(s): @aleksey-kotsuba, @vitaliiivanovspryker, @andrew-maslov

- Ticket: https://spryker.atlassian.net/browse/CC-11193, 
               https://spryker.atlassian.net/browse/TE-6081



#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Adyen                 | minor                 |                       |

-----------------------------------------

#### Module Adyen

##### Change log

Improvements:
- Adjusted `DirectDebitSubForm` in order to have `NotBlank` constraint on `owner_name` and `owner_iban` fields.
- Adjusted `spy_payment_adyen.payment_method` field with option `size="64"`.
- Adjusted `spy_payment_adyen.order_reference` field with option `size="64"`.
- Adjusted `spy_payment_adyen.reference` field with option `size="128"`.
- Adjusted `spy_payment_adyen.psp_reference` field with option `size="64"`.
- Adjusted `spy_payment_adyen.details` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen.payment_data` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen.additional_data` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen_order_item.status` field with option `size="64"`.
- Adjusted `spy_payment_adyen_api_log.type` field with option `size="128"`.
- Adjusted `spy_payment_adyen_api_log.request` field with option `size="128"`.
- Adjusted `spy_payment_adyen_api_log.request` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen_api_log.response` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen_api_log.error_code` field with option `size="128"`.
- Adjusted `spy_payment_adyen_api_log.error_message` field with option `size="255"`.
- Adjusted `spy_payment_adyen_api_log.error_type` field with option `size="128"`.
- Adjusted `spy_payment_adyen_notification.psp_reference` field with option `size="64"`.
- Adjusted `spy_payment_adyen_notification.event_code` field with option `size="128"`.
- Adjusted `spy_payment_adyen_notification.success` field with option `size="32"`.
- Adjusted `spy_payment_adyen_notification.additional_data` field to have `type="LONGVARCHAR"`.
- Adjusted `spy_payment_adyen_notification.amount` field with option `size="32"`.
- Adjusted `spy_payment_adyen_notification.operations` field with option `size="255"`.
- Adjusted `spy_payment_adyen_notification.event_date` field with option `size="255"`.
- Adjusted `spy_payment_adyen_notification.merchant_account_code` field with option `size="255"`.
- Adjusted `spy_payment_adyen_notification.merchant_reference` field with option `size="128"`.
- Adjusted `spy_payment_adyen_notification.payment_method` field with option `size="128"`.
- Adjusted `spy_payment_adyen_notification.reason` field with option `size="255"`.